### PR TITLE
Fix renderer just not working

### DIFF
--- a/SS14.MapServer/BuildRunners/LocalBuildService.cs
+++ b/SS14.MapServer/BuildRunners/LocalBuildService.cs
@@ -116,7 +116,7 @@ public sealed partial class LocalBuildService
         var log = logBuffer.ToString();
         // Bandaid the fact that the map renderer doesn't return an error code when rendering fails
 
-        if (process.ExitCode != 0 || LogErrorRegex().IsMatch(log))
+        if (process.ExitCode != 0 || RendererFailureRegex().IsMatch(log))
         {
             var exception = new BuildException($"Error while running: {command} {string.Join(' ', arguments)}");
             ProcessLocalBuildException(log, "run.log", exception);
@@ -157,6 +157,6 @@ public sealed partial class LocalBuildService
             });
     }
 
-    [GeneratedRegex("error?|exception|fatal")]
-    private static partial Regex LogErrorRegex();
+    [GeneratedRegex(@"(?im)(\[(ERRO|FATL)\])|(^Unhandled exception\.)|(^\s*System\.[\w.]+Exception\b)", RegexOptions.CultureInvariant)]
+    private static partial Regex RendererFailureRegex();
 }


### PR DESCRIPTION
When the client starts up, this line was causing issues with the exception regex
```CLIENT: 0.005s [DEBG] root: Compile Options: DEVELOPMENT;RELEASE;EXCEPTION_TOLERANCE```

Very silly but it was causing the build to be marked as failed every time, even when it rendered successfully. I am not good at regex, but as far as my knowledge goes this should cover all the possible failures that could occur without tripping up over minor things